### PR TITLE
feat(exchange): add missing dtos and types

### DIFF
--- a/backend/src/modules/exchanges/dto/create-exchange-account.dto.ts
+++ b/backend/src/modules/exchanges/dto/create-exchange-account.dto.ts
@@ -1,0 +1,38 @@
+import {
+  IsEnum,
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsObject,
+} from 'class-validator';
+
+export enum ExchangeType {
+  BINANCE = 'BINANCE',
+  BYBIT = 'BYBIT',
+  OKX = 'OKX',
+  GATE = 'GATE',
+  BITGET = 'BITGET',
+}
+
+export class CreateExchangeAccountDto {
+  @IsEnum(ExchangeType)
+  exchange: ExchangeType;
+
+  @IsString()
+  apiKey: string;
+
+  @IsString()
+  secretKey: string;
+
+  @IsOptional()
+  @IsString()
+  passphrase?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isTestnet?: boolean;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/backend/src/modules/exchanges/dto/update-exchange-account.dto.ts
+++ b/backend/src/modules/exchanges/dto/update-exchange-account.dto.ts
@@ -1,0 +1,18 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateExchangeAccountDto } from './create-exchange-account.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export enum AccountStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
+  PENDING_APPROVAL = 'PENDING_APPROVAL',
+}
+
+export class UpdateExchangeAccountDto extends PartialType(
+  CreateExchangeAccountDto,
+) {
+  @IsOptional()
+  @IsEnum(AccountStatus)
+  status?: AccountStatus;
+}

--- a/backend/src/modules/exchanges/types/exchange.types.ts
+++ b/backend/src/modules/exchanges/types/exchange.types.ts
@@ -1,0 +1,45 @@
+export enum ExchangeType {
+  BINANCE = 'BINANCE',
+  BYBIT = 'BYBIT',
+  OKX = 'OKX',
+  GATE = 'GATE',
+  BITGET = 'BITGET',
+}
+
+export enum AccountStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
+  PENDING_APPROVAL = 'PENDING_APPROVAL',
+}
+
+export interface ExchangeCredentials {
+  apiKey: string;
+  secretKey: string;
+  passphrase?: string;
+}
+
+export interface OrderRequest {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  type: 'MARKET' | 'LIMIT';
+  quantity: string;
+  price?: string;
+  additionalParams?: Record<string, any>;
+}
+
+export interface OrderResponse {
+  orderId: string;
+  symbol: string;
+  status: string;
+  executedQty?: string;
+  price?: string;
+  timestamp: number;
+}
+
+export interface ExchangeBalance {
+  asset: string;
+  free: string;
+  locked: string;
+  total: string;
+}


### PR DESCRIPTION
## Summary
- add DTOs for creating and updating exchange accounts
- define shared exchange enums and interfaces under the exchanges module
- update exchange service imports and lint issues to use the new structures

## Testing
- npm --workspace backend run lint

------
https://chatgpt.com/codex/tasks/task_b_68d0f18d9c88832ca93f09fb349d32d5