### PR TITLE
fix: use dynamic backend base url for listings

### DIFF
--- a/frontend/components/landing/LandingPage.tsx
+++ b/frontend/components/landing/LandingPage.tsx
@@ -77,10 +77,18 @@ export function LandingPage({ copy, locale }: LandingPageProps) {
     </div>
   );
 
-  const apiBase = useMemo(
-    () => process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080/api",
-    [],
-  );
+  const apiBase = useMemo(() => {
+    const envValue = process.env.NEXT_PUBLIC_BACKEND_URL?.trim();
+    if (envValue && envValue.length > 0) {
+      return envValue.replace(/\/$/, "");
+    }
+
+    if (typeof window !== "undefined") {
+      return `${window.location.origin}/api`;
+    }
+
+    return "/api";
+  }, []);
 
   const { events, connected, lastSyncedAt } = useListingStream(apiBase, {
     fallbackEvents: FALLBACK_EVENTS,


### PR DESCRIPTION
## Summary
- derive the listings API base URL from the configured environment variable or the current origin at runtime
- fall back to the same-origin /api path when no environment variable is provided so the landing page can connect in production

## Testing
- npm run lint --workspace frontend

------
https://chatgpt.com/codex/tasks/task_b_68d8017c9234832c820d87b34ab64561